### PR TITLE
分离.douban_token.txt与.doubanfm_config的写入

### DIFF
--- a/douban/douban_token.py
+++ b/douban/douban_token.py
@@ -93,8 +93,9 @@ class Doubanfm(object):
                     with open(path_token, 'w') as f:
                         pickle.dump(self.login_data, f)
                     break
-            # 配置文件
-            path_config = os.path.expanduser('~/.doubanfm_config')
+        # 配置文件
+        path_config = os.path.expanduser('~/.doubanfm_config')
+        if not os.path.exists(path_config):
             config ='''[key]
 UP = k
 DOWN = j


### PR DESCRIPTION
消除之前已登录用户升级版本后再次登录默认不写入.doubanfm_config导致界面失效的bug。
