### PR TITLE
统一心标的空格显示

### DIFF
--- a/douban/cli.py
+++ b/douban/cli.py
@@ -36,7 +36,7 @@ class Cli(object):
     TITLE = PREFIX_DESELECTED  # 标题
 
     def __init__(self, lines):
-        self.love = colored('♥', 'red')
+        self.love = colored(' ♥ ', 'red')
         self.lines = lines
         self.markline = 0  # 箭头行 初始化设置默认频道
         self.topline = 0  # lines

--- a/douban/douban.py
+++ b/douban/douban.py
@@ -271,7 +271,7 @@ class Win(cli.Cli):
         self.thread(self.init_notification)  # 桌面通知
 
         if song['like'] == 1:
-            love = self.love + ' '
+            love = self.love
         else:
             love = ''
         title = green(song['title'])
@@ -640,7 +640,6 @@ class History(cli.Cli):
         self.win = win
         self.KEYS = self.win.KEYS
         # the playlist of the history
-        self.love = red(' ♥ ')
         self.screen_height, self.screen_width = self.linesnum()
 
         # 3个tab, playlist thistory rate


### PR DESCRIPTION
统一给心型加上左右空格，放置在 self.love 中，不再在各个需要的地方单独加空格。