### PR TITLE
Fixed login problem, channel selection and some other issues

### DIFF
--- a/douban/config.py
+++ b/douban/config.py
@@ -7,8 +7,8 @@ import cPickle as pickle
 
 
 PATH_CONFIG = os.path.expanduser("~/.doubanfm_config")
-PATH_HISTORY = os.path.expanduser('~/.douban_history')
-PATH_TOKEN = os.path.expanduser('~/.douban_token.txt')
+PATH_HISTORY = os.path.expanduser('~/.doubanfm_history')
+PATH_TOKEN = os.path.expanduser('~/.doubanfm_token')
 CONFIG = '''
 [key]
 UP = k

--- a/douban/douban.py
+++ b/douban/douban.py
@@ -414,7 +414,7 @@ class Win(cli.Cli):
         # store the history of playlist
         config.set_history(self.history)
         logger.info('History saved.')
-        # stroe the token and the default info
+        # store the token and the default info
         config.set_default(self._volume, self._channel)
         logger.info('Settings saved.')
         sys.exit(0)

--- a/douban/douban.py
+++ b/douban/douban.py
@@ -103,8 +103,8 @@ class Win(cli.Cli):
             else color_func(self.c['TITLE']['doubanfm'])(' Last.fm ')
 
         self.TITLE += '\ ' + \
-                color_func(self.c['TITLE']['username'])(self.douban.user_name) + \
-                ' >>\r'
+            color_func(self.c['TITLE']['username'])(self.douban.user_name) + \
+            ' >>\r'
 
         # 启动自动播放
         self.markline = self.displayline = self._channel
@@ -118,17 +118,18 @@ class Win(cli.Cli):
         self.run()
 
     def reload_theme(self):
-        cli.Cli.PREFIX_SELECTED = color_func(self.c['LINE']['arrow'])('  > ')  # 箭头所指行前缀
+        # 箭头所指行前缀
+        cli.Cli.PREFIX_SELECTED = color_func(self.c['LINE']['arrow'])('  > ')
         cli.Cli.LOVE = color_func(self.c['PLAYINGSONG']['like'])(' ❤ ', 'red')
 
-        self.TITLE =  cli.Cli.TITLE +\
+        self.TITLE = cli.Cli.TITLE +\
             color_func(self.c['TITLE']['doubanfm'])(' Douban Fm ') \
             if not self.douban.lastfm\
             else color_func(self.c['TITLE']['doubanfm'])(' Last.fm ')
 
         self.TITLE += '\ ' + \
-                color_func(self.c['TITLE']['username'])(self.douban.user_name) + \
-                ' >>'
+            color_func(self.c['TITLE']['username'])(self.douban.user_name) + \
+            ' >>'
         self.set_suffix_selected(self.playingsong)
 
     def set_suffix_selected(self, song):
@@ -243,13 +244,15 @@ class Win(cli.Cli):
             self._player_exit_event.clear()     # Clear the event
             logger.debug('Noticed player exit.')
             # If self.q (about to quit), just quit
+            if self.q:
+                return
+            self.thread(self.douban.submit_music, args=(self.playingsong,))
             # If some thread has already called play(), just pass
-            if not self.q and not self.lock_start:
-                self.thread(self.douban.submit_music, args=(self.playingsong,))
+            if not self.lock_start:
                 self.play()
 
     def get_playlist(self):
-        self.playlist = self.douban.get_playlist(self._channel)
+        self.playlist = self.douban.get_playlist()
 
     def get_song(self):
         if not self.playlist:
@@ -330,7 +333,7 @@ class Win(cli.Cli):
             elif k == ' ':                   # 空格选择频道,播放歌曲
                 if self.markline + self.topline != self.displayline:
                     self.displaysong()
-                    self.set_play()
+                    self.set_channel()
             elif k == self.KEYS['OPENURL']:  # l打开当前播放歌曲豆瓣页
                 self.set_url()
             elif k == self.KEYS['BYE']:      # b不再播放
@@ -420,15 +423,15 @@ class Win(cli.Cli):
         sys.exit(0)
 
     @info('正在加载请稍后...')
-    def set_play(self):
+    def set_channel(self):
         '''开始播放'''
         logger.debug(str(self.displayline) + str(self._channel))
         self._channel = self.displayline
-        self.lock_start = True
-        # self.playingsong = {}
-        self.player.quit()
-        self._channel = self.displayline
+        self.douban.set_channel(self._channel)
         self.get_playlist()
+        self.lock_loop = False
+        self.lock_start = True
+        self.player.quit()
         self.play()
 
     @info('正在加载请稍后...')

--- a/douban/douban_token.py
+++ b/douban/douban_token.py
@@ -92,11 +92,13 @@ class Doubanfm(object):
     def init_login(self):
         print LOGO
         self.douban_login()  # 登陆
-        self.login_lastfm()  # 登陆 last.fm
+        self.lastfm_login()  # 登陆 last.fm
         print '\033[31m♥\033[0m Get channels ',
-        # self.get_channels()  # 获取频道列表
+        self.get_channels()  # 获取频道列表
         print '[\033[32m OK \033[0m]'
-        # self.get_channellines()  # 重构列表用以显示
+        # 存储的default_channel是行数而不是真正发送数据的channel_id
+        # 这里需要进行转化一下
+        self.set_channel(self.default_channel)
         print '\033[31m♥\033[0m Check PRO ',
         # self.is_pro()
         print '[\033[32m OK \033[0m]'
@@ -107,8 +109,30 @@ class Doubanfm(object):
         password = getpass.getpass('Password: ')
         return email, password
 
-    def login_lastfm(self):
+    def lastfm_login(self):
         '''Last.fm登陆'''
+        # username & password
+        self.last_fm_username = \
+            self.login_data['last_fm_username'] if 'last_fm_username' in self.login_data\
+            else None
+        self.last_fm_password = \
+            self.login_data['last_fm_password'] if 'last_fm_password' in self.login_data\
+            else None
+        if len(sys.argv) > 1 and sys.argv[1] == 'last.fm':
+            from hashlib import md5
+            username = raw_input('Last.fm username: ') or None
+            password = getpass.getpass('Last.fm password :') or None
+            if username and password:
+                self.last_fm_username = username
+                self.last_fm_password = md5(password).hexdigest()
+            with open(config.PATH_TOKEN, 'r') as f:
+                data = pickle.load(f)
+            with open(config.PATH_TOKEN, 'w') as f:
+                data['last_fm_username'] = username
+                data['last_fm_password'] = self.last_fm_password
+                pickle.dump(data, f)
+
+        # login
         if self.lastfm and self.last_fm_username and self.last_fm_password:
             self.scrobbler = Scrobbler(
                 self.last_fm_username, self.last_fm_password)
@@ -158,11 +182,10 @@ class Doubanfm(object):
 
     def douban_login(self):
         '''登陆douban.fm获取token'''
-        path_token = os.path.expanduser('~/.douban_token.txt')
-        if os.path.exists(path_token):
+        if os.path.exists(config.PATH_TOKEN):
             # 已登陆
             logger.info("Found existing Douban.fm token.")
-            with open(path_token, 'r') as f:
+            with open(config.PATH_TOKEN, 'r') as f:
                 self.login_data = pickle.load(f)
                 self.token = self.login_data['token']
                 self.user_name = self.login_data['user_name']
@@ -170,13 +193,12 @@ class Doubanfm(object):
                 self.expire = self.login_data['expire']
                 self.default_volume = int(self.login_data['volume'])\
                     if 'volume' in self.login_data else 50
+                # Value stored in login_data in token file is lien number
+                # instead of channel_id! Will do set_channel later.
                 self.default_channel = int(self.login_data['channel'])\
-                    if 'channel' in self.login_data else 1
-
-                # 存储的default_channel是行数而不是真正发送数据的channel_id
-                # 这里需要进行转化一下
-                self.set_channel(self.default_channel)
-            print '\033[31m♥\033[0m Get local token - Username: \033[33m%s\033[0m' % self.user_name
+                    if 'channel' in self.login_data else 0
+            print '\033[31m♥\033[0m Get local token - Username: \033[33m%s\033[0m' %\
+                self.user_name
         else:
             # 未登陆
             logger.info('First time logging in Douban.fm.')
@@ -211,51 +233,28 @@ class Doubanfm(object):
                         'channel': '0'
                     }
                     logger.info('Logged in username: ' + self.user_name)
-                    with open(path_token, 'w') as f:
+                    with open(config.PATH_TOKEN, 'w') as f:
                         pickle.dump(self.login_data, f)
-                        logger.debug('Write data to ' + path_token)
+                        logger.debug('Write data to ' + config.PATH_TOKEN)
                     break
-
-        self.last_fm_username = \
-            self.login_data['last_fm_username'] if 'last_fm_username' in self.login_data\
-            else None
-        self.last_fm_password = \
-            self.login_data['last_fm_password'] if 'last_fm_password' in self.login_data\
-            else None
-        # last.fm登陆
-        try:
-            if sys.argv[1] == 'last.fm':
-                from hashlib import md5
-                username = raw_input('last.fm username:') or None
-                password = getpass.getpass('last.fm password:') or None
-                if username and password:
-                    self.last_fm_username = username
-                    self.last_fm_password = md5(password).hexdigest()
-                with open(path_token, 'r') as f:
-                    data = pickle.load(f)
-                with open(path_token, 'w') as f:
-                    data['last_fm_username'] = username
-                    data['last_fm_password'] = self.last_fm_password
-                    pickle.dump(data, f)
-        except IndexError:
-            pass
         # set config
         config.init_config()
 
-    @property
-    def channels(self):
-        '''获取channel，存入self.channels'''
+    def get_channels(self):
+        '''获取channel列表，将channel name/id存入self._channel_list'''
         # 红心兆赫需要手动添加
-        channels = [{
+        self._channel_list = [{
             'name': '红心兆赫',
             'channel_id': -3
         }]
         r = requests.get('http://www.douban.com/j/app/radio/channels')
-        channels += json.loads(r.text, object_hook=_decode_dict)['channels']
+        self._channel_list += json.loads(r.text, object_hook=_decode_dict)['channels']
+
+    @property
+    def channels(self):
+        '''返回channel名称列表（一个list，不包括id）'''
         # 格式化频道列表，以便display
-        lines = []
-        for channel in channels:
-            lines.append(channel['name'])
+        lines = [ch['name'] for ch in self._channel_list]
         return lines
 
     def requests_url(self, ptype, **data):
@@ -272,16 +271,13 @@ class Doubanfm(object):
 
         return s.text
 
-    def set_channel(self, channel):
+    def set_channel(self, line):
         '''把行数转化成channel_id'''
-        self.default_channel = channel
-        channel = -3 if channel == 0 else channel - 1
-        self.login_data['channel'] = channel
+        self.default_channel = line
+        self.login_data['channel'] = self._channel_list[line]['channel_id']
 
-    def get_playlist(self, channel):
+    def get_playlist(self):
         '''获取播放列表,返回一个list'''
-        if self.default_channel != channel:
-            self.set_channel(channel)
         s = self.requests_url('n')
         return json.loads(s, object_hook=_decode_dict)['song']
 
@@ -298,12 +294,10 @@ class Doubanfm(object):
     def rate_music(self, playingsong):
         '''标记喜欢歌曲'''
         self.requests_url('r', sid=playingsong['sid'])
-        # self.playlist = eval(s)['song']
 
     def unrate_music(self, playingsong):
         '''取消标记喜欢歌曲'''
         self.requests_url('u', sid=playingsong['sid'])
-        # self.playlist = eval(s)['song']
 
     def submit_music(self, playingsong):
         '''歌曲结束标记'''
@@ -330,7 +324,7 @@ class Doubanfm(object):
             return lrc_dic
         except requests.exceptions.RequestException:
             logger.error('Get lyric failed!')
-            return 0
+            return {}
 
 
 def main():
@@ -340,7 +334,7 @@ def main():
     douban.init_login()  # 登录
     print douban.login_data
     print douban.channels
-    print douban.get_playlist(-3)
+    print douban.get_playlist()
 
 if __name__ == '__main__':
     main()

--- a/douban/douban_token.py
+++ b/douban/douban_token.py
@@ -57,6 +57,7 @@ LOGO = '''
 
 logger = logging.getLogger('doubanfm.token')
 
+
 def _decode_list(data):
     rv = []
     for item in data:
@@ -64,24 +65,24 @@ def _decode_list(data):
             item = item.encode('utf-8')
         elif isinstance(item, list):
             item = _decode_list(item)
-        elif isinstance(item, dict):
-            item = _decode_dict(item)
         rv.append(item)
     return rv
+
 
 def _decode_dict(data):
     rv = {}
     for key, value in data.iteritems():
         if isinstance(key, unicode):
             key = key.encode('utf-8')
+
         if isinstance(value, unicode):
             value = value.encode('utf-8')
         elif isinstance(value, list):
             value = _decode_list(value)
-        elif isinstance(value, dict):
-            value = _decode_dict(value)
+        # no need to recurse into dict, json library will do that
         rv[key] = value
     return rv
+
 
 class Doubanfm(object):
     def __init__(self):
@@ -102,8 +103,8 @@ class Doubanfm(object):
 
     def win_login(self):
         '''登陆界面'''
-        email = raw_input('Email:')
-        password = getpass.getpass('Password:')
+        email = raw_input('Email: ')
+        password = getpass.getpass('Password: ')
         return email, password
 
     def login_lastfm(self):
@@ -188,7 +189,7 @@ class Doubanfm(object):
                     'password': self.password
                 }
                 s = requests.post('http://www.douban.com/j/app/login', login_data)
-                dic = json.loads(s.text, object_hook=_decode_dict)['song']
+                dic = json.loads(s.text, object_hook=_decode_dict)
                 if dic['r'] == 1:
                     logger.debug(dic['err'])
                     continue
@@ -307,7 +308,6 @@ class Doubanfm(object):
     def submit_music(self, playingsong):
         '''歌曲结束标记'''
         self.requests_url('e', sid=playingsong['sid'])
-
 
     def get_lrc(self, playingsong):
         '''获取歌词'''


### PR DESCRIPTION
Login was broken due to accessing the wrong key of the result dictionary.

Channel selection has been broken for some time, because of the ambiguity between "line number" and "channel id".

I now assign a separate process group to mplayer and will kill the whole process group when asking to quit the player. Hopefully this will solve the can-not-quit-completely-when-initializing problem.

BTW, I changed the name of token file. Need to re-login.