### PR TITLE
change douban api protocol to https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ lib64
 __pycache__
 *~
 .idea/
+.DS_Store

--- a/doubanfm/API/api.py
+++ b/doubanfm/API/api.py
@@ -46,29 +46,45 @@ class Doubanfm(object):
         """
         self._channel_list = [
             {'name': '红心兆赫', 'channel_id': -3},
-            {'name': '私人兆赫', 'channel_id': 0},
+            {'name': '我的私人兆赫', 'channel_id': 0},
             {'name': '每日私人歌单', 'channel_id': -2},
             {'name': '豆瓣精选兆赫', 'channel_id': -10},
+            # 心情 / 场景
+            {'name': '工作学习', 'channel_id': 153},
+            {'name': '户外', 'channel_id': 151},
+            {'name': '休息', 'channel_id': 152},
+            {'name': '亢奋', 'channel_id': 154},
+            {'name': '舒缓', 'channel_id': 155},
+            {'name': 'Easy', 'channel_id': 77},
+            {'name': '咖啡', 'channel_id': 32},
+            # 语言 / 年代
             {'name': '华语', 'channel_id': 1},
-            {'name': '粤语', 'channel_id': 6},
             {'name': '欧美', 'channel_id': 2},
-            {'name': '法语', 'channel_id': 22},
+            {'name': '七零', 'channel_id': 3},
+            {'name': '八零', 'channel_id': 4},
+            {'name': '九零', 'channel_id': 5},
+            {'name': '粤语', 'channel_id': 6},
             {'name': '日语', 'channel_id': 17},
             {'name': '韩语', 'channel_id': 18},
-            {'name': '民谣', 'channel_id': 8},
+            {'name': '法语', 'channel_id': 22},
+            {'name': '新歌', 'channel_id': 61},
+            # 风格 / 流派
+            {'name': '流行', 'channel_id': 194},
             {'name': '摇滚', 'channel_id': 7},
-            {'name': '爵士', 'channel_id': 13},
-            {'name': '古典', 'channel_id': 27},
-            {'name': '电子', 'channel_id': 14},
-            {'name': 'R&B', 'channel_id': 16},
-            {'name': '说唱', 'channel_id': 15},
-            {'name': '女声', 'channel_id': 20},
-            {'name': '动漫', 'channel_id': 28},
-            {'name': '咖啡', 'channel_id': 32},
+            {'name': '民谣', 'channel_id': 8},
+            {'name': '轻音乐', 'channel_id': 9},
             {'name': '电影原声', 'channel_id': 10},
-            {'name': '70年代', 'channel_id': 3},
-            {'name': '80年代', 'channel_id': 4},
-            {'name': '90年代', 'channel_id': 5},
+            {'name': '爵士', 'channel_id': 13},
+            {'name': '电子', 'channel_id': 14},
+            {'name': '说唱', 'channel_id': 15},
+            {'name': 'R&B', 'channel_id': 16},
+            {'name': '古典', 'channel_id': 27},
+            {'name': '动漫', 'channel_id': 28},
+            {'name': '世界音乐', 'channel_id': 187},
+            {'name': '布鲁斯', 'channel_id': 188},
+            {'name': '拉丁', 'channel_id': 189},
+            {'name': '雷鬼', 'channel_id': 190},
+            {'name': '小清新', 'channel_id': 76}
         ]
 
     def _get_channel_id(self, line):
@@ -104,7 +120,7 @@ class Doubanfm(object):
         return lines
 
     def get_daily_songs(self):
-        url = 'https://douban.fm/j/v2/songlist/user_daily'
+        url = 'https://douban.fm/j/v2/songlist/user_daily/?kbps=320'
         s = requests.get(url, cookies=self._cookies, headers=HEADERS)
         req_json = s.json()
         # TODO: 验证
@@ -124,13 +140,17 @@ class Doubanfm(object):
             'type': ptype,
             'pt': '3.1',
             'channel': self._channel_id,
-            'pb': '128',
+            'pb': '320',
             'from': 'mainsite',
-            'r': ''
+            'r': '',
+            'kbps': '320',
+            'app_name': 'radio_website',
+            'client': 's:mainsite|y:3.0',
+            'version': '100'
         }
         if 'sid' in data:
             options['sid'] = data['sid']
-        url = 'https://douban.fm/j/mine/playlist'
+        url = 'https://douban.fm/j/v2/playlist'
         while 1:
             try:
                 s = requests.get(url, params=options, cookies=self._cookies, headers=HEADERS)

--- a/doubanfm/API/api.py
+++ b/doubanfm/API/api.py
@@ -82,7 +82,7 @@ class Doubanfm(object):
         这个貌似没啥用
         :params fcid, tcid: string
         """
-        url = 'http://douban.fm/j/change_channel'
+        url = 'https://douban.fm/j/change_channel'
         options = {
             'fcid': fcid,
             'tcid': tcid,
@@ -104,7 +104,7 @@ class Doubanfm(object):
         return lines
 
     def get_daily_songs(self):
-        url = 'http://douban.fm/j/v2/songlist/user_daily'
+        url = 'https://douban.fm/j/v2/songlist/user_daily'
         s = requests.get(url, cookies=self._cookies, headers=HEADERS)
         req_json = s.json()
         # TODO: 验证
@@ -130,7 +130,7 @@ class Doubanfm(object):
         }
         if 'sid' in data:
             options['sid'] = data['sid']
-        url = 'http://douban.fm/j/mine/playlist'
+        url = 'https://douban.fm/j/mine/playlist'
         while 1:
             try:
                 s = requests.get(url, params=options, cookies=self._cookies, headers=HEADERS)
@@ -205,7 +205,7 @@ class Doubanfm(object):
          'request': 'POST /v2/fm/lyric'}
         """
         try:
-            url = "http://api.douban.com/v2/fm/lyric"
+            url = "https://api.douban.com/v2/fm/lyric"
             postdata = {
                 'sid': playingsong['sid'],
                 'ssid': playingsong['ssid'],

--- a/doubanfm/API/login.py
+++ b/doubanfm/API/login.py
@@ -23,10 +23,14 @@ def win_login():
     password = getpass.getpass(PASS_INFO)
     captcha_id = get_captcha_id()
     get_capthca_pic(captcha_id)
-
-    import webbrowser
-    url = "file:///tmp/captcha_pic.jpg"
-    webbrowser.open(url)
+    file = '/tmp/captcha_pic.jpg'
+    try:
+        from subprocess import call
+        from os.path import expanduser
+        call([expanduser('~') + '/.iterm2/imgcat', file])
+    except:
+        import webbrowser
+        webbrowser.open('file://' + file)
     captcha_solution = raw_input(CAPTCHA_INFO)
     return email, password, captcha_solution, captcha_id
 
@@ -91,9 +95,10 @@ def request_token():
 def get_captcha_id():
     try:
         r = requests.get('https://douban.fm/j/new_captcha', headers=HEADERS)
+        r.raise_for_status()
         return r.text.strip('"')
     except Exception as e:
-        raise APIError('get_captcha_id error ' + e)
+        raise APIError('get captcha id error: ' + str(e))
 
 
 def get_capthca_pic(captcha_id=None):
@@ -111,4 +116,4 @@ def get_capthca_pic(captcha_id=None):
             for chunk in r.iter_content(1024):
                 f.write(chunk)
     else:
-        print "get_captcha_pic " + r.status_code
+        print "get captcha pic error with http code:" + str(r.status_code)

--- a/doubanfm/API/login.py
+++ b/doubanfm/API/login.py
@@ -65,7 +65,7 @@ def request_token():
             'captcha_id': captcha_id,
             'task': 'sync_channel_list'
         }
-        r = requests.post('http://douban.fm/j/login', data=options, headers=HEADERS)
+        r = requests.post('https://douban.fm/j/login', data=options, headers=HEADERS)
         req_json = json.loads(r.text, object_hook=decode_dict)
         if req_json['r'] == 0:
             post_data = {
@@ -90,7 +90,7 @@ def request_token():
 
 def get_captcha_id():
     try:
-        r = requests.get('http://douban.fm/j/new_captcha', headers=HEADERS)
+        r = requests.get('https://douban.fm/j/new_captcha', headers=HEADERS)
         return r.text.strip('"')
     except Exception as e:
         raise APIError('get_captcha_id error ' + e)
@@ -101,7 +101,7 @@ def get_capthca_pic(captcha_id=None):
         'size': 'm',
         'id': captcha_id
     }
-    r = requests.get('http://douban.fm/misc/captcha',
+    r = requests.get('https://douban.fm/misc/captcha',
                      params=options,
                      headers=HEADERS)
     if r.status_code == 200:


### PR DESCRIPTION
#126 #118 中"帐号不能为空"错误，是因为原来登录使用的http会强制redirect到https返回的结果永远是
```javascript
{"err_no":1001,"r":1,"err_msg":"帐号不能为空"}
```