### PR TITLE
terminal mess up after quit fix

### DIFF
--- a/doubanfm/check.py
+++ b/doubanfm/check.py
@@ -8,7 +8,7 @@ from doubanfm.exceptions import MplayerError
 
 
 def is_latest(package_name):
-    pypi = xmlrpclib.ServerProxy('http://pypi.python.org/pypi')
+    pypi = xmlrpclib.ServerProxy('https://pypi.python.org/pypi')
     for dist in pip.get_installed_distributions():
         if dist.project_name == package_name:
             available = pypi.package_releases(dist.project_name)

--- a/doubanfm/douban.py
+++ b/doubanfm/douban.py
@@ -86,7 +86,7 @@ class Router(object):
     def quit(self):
         # 退出保存信息
         self.data.save()
-        subprocess.call('echo -e "\033[?25h";clear', shell=True)
+        subprocess.call('echo -e "\033[?25h";clear;stty sane', shell=True)
 
     def _watchdog_key(self):
         """


### PR DESCRIPTION
the terminal come to mess up after quit douban.fm, it looks like below:

<img width="834" alt="2016-06-24 3 45 05" src="https://cloud.githubusercontent.com/assets/743166/16331789/146b3b94-3a25-11e6-9786-1cef65d91234.png">
