### PR TITLE
Remove unused dependency pycookiecheat

### DIFF
--- a/doubanfm/API/login.py
+++ b/doubanfm/API/login.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
-from pycookiecheat import chrome_cookies
 from termcolor import colored
 import requests
 import getpass

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,7 @@ setup(name='douban.fm',
       zip_safe=True,
       install_requires=[
         'termcolor',
-        'requests',
-        'pycookiecheat'
+        'requests'
       ],
       entry_points={
         'console_scripts':[


### PR DESCRIPTION
Error message: invalid syntax (pycookiecheat.py, line 27) #149